### PR TITLE
fixing typo in documentation

### DIFF
--- a/doc/fastq-grep.1
+++ b/doc/fastq-grep.1
@@ -10,7 +10,7 @@ fastq-grep - print sequences matching a pattern
 Given a PATTERN, specified as a perl-compatible regular expression, print every
 FASTQ entry with a matching nucleotide sequence.
 
-One ore more FILEs may be specified, otherwise input is read from standard input.
+One or more FILEs may be specified, otherwise input is read from standard input.
 
 .SH OPTIONS
 .TP

--- a/doc/fastq-kmers.1
+++ b/doc/fastq-kmers.1
@@ -27,7 +27,7 @@ For a given k, for example k = 4, a table in the following format is output,
 .br
 #TTTT^876#
 
-One ore more FILEs may be specified, otherwise input is read from standard input.
+One or more FILEs may be specified, otherwise input is read from standard input.
 Input files may be gziped.
 
 .SH OPTIONS

--- a/doc/fastq-match.1
+++ b/doc/fastq-match.1
@@ -11,7 +11,7 @@ Given a nucleotide sequence QUERY, perform local alignment against every FASTQ
 sequence using the Smith-Waterman algorithm. For each read, an alignment score
 is printed, so that the output consists of a simple list of scores.
 
-One ore more FILEs may be specified, otherwise input is read from standard input.
+One or more FILEs may be specified, otherwise input is read from standard input.
 Input files may be gziped.
 
 .SH OPTIONS

--- a/doc/fastq-qualadj.1
+++ b/doc/fastq-qualadj.1
@@ -12,7 +12,7 @@ be negative. This helps in converting from one scale to another. For example, to
 convert reads in Phred+64 (Illumina 1.3) scale to the Phred+33 scale, on offset
 of -31 can be specified.
 
-One ore more FILEs may be specified, otherwise input is read from standard input.
+One or more FILEs may be specified, otherwise input is read from standard input.
 Input files may be gziped.
 
 .SH OPTIONS

--- a/doc/fastq-uniq.1
+++ b/doc/fastq-uniq.1
@@ -16,7 +16,7 @@ sequence identifiers formatted as,
 Where, N in a unique number assigned to the sequence and M is the number of
 copies occurring.
 
-One ore more FILEs may be specified, otherwise input is read from standard input.
+One or more FILEs may be specified, otherwise input is read from standard input.
 Input files may be gziped.
 
 .SH OPTIONS


### PR DESCRIPTION
Hello,

I noticed a typo in the documentation for several of the commands. Hopefully, I've fixed the problem in the right place. Thanks for providing these useful tools.

Matt