### PR TITLE
Added posix_c_source to config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ AS_IF([test "x$enable_debug" = xyes],
       [CFLAGS="$opt_CFLAGS"])
 
 AC_DEFINE(_FILE_OFFSET_BITS, 64)
+AC_DEFINE(_POSIX_C_SOURCE, 200809L)
 AC_DEFINE(_POSIX_SOURCE) # needed for fileno
 
 AC_PROG_LIBTOOL


### PR DESCRIPTION
I am compiling on MacOS Sonoma 14.7.3 and ran into the same issue as https://github.com/dcjones/fastq-tools/issues/32

I am not fully sure of the problem, but debugging with Claude gave the suggestion that not all POSIX functions would be available just by specifying the C standard as >= 99. Compiles and runs fine for me now.